### PR TITLE
Fix rss.xml template

### DIFF
--- a/crotal/init/public/rss.xml
+++ b/crotal/init/public/rss.xml
@@ -9,7 +9,7 @@
     {% for post in posts %}
     <item>
       <title>{{ post.title }}</title>
-      <description>{{ post.html | striptags | truncate(length=255 ,killwords=True)}}</description>
+      <description>{{ post.html | striptags | escape | truncate(length=255 ,killwords=True)}}</description>
       <link>{{ site.site_url }}{{ post.url }}</link>
       <pubDate>{{ post.pub_time}} +0800</pubDate>
       2012-11-20 13:55:00 +0100


### PR DESCRIPTION
I had text like this in my post:

```
>>>> d = {'a': 1, 'b': 2, 'c': 3}
>>> da = d['a']
>>> da
```

But when the rss.xml was generated, the '>>>' characters were simple copied to the output and there was a complaint about invalid characters in browser. So I added JINJA2 tag "| escape" to the template which escapes invalid characters (&, <,  >, ...) to HTML entities.
