### PR TITLE
Adding support for local rsync deployment

### DIFF
--- a/crotal/init/_config.yml
+++ b/crotal/init/_config.yml
@@ -11,6 +11,7 @@ navbar: [Home: /, Archives: /archive, Categories: /category, About: /about, RSS:
 email:
 
 deploy_default: rsync
+# if you want to deploy to a local folder, just leave ip empty
 ip: root@8.8.8.8
 deploy_dir: /var/www/test
 

--- a/crotal/rsync.py
+++ b/crotal/rsync.py
@@ -2,8 +2,13 @@ import os
 
 
 def rsync_deploy(dir, config):
-    print 'Deploying by Rsync ...'
-    os.system("rsync -avz %s %s:%s" % (dir, config.ip, config.deploy_dir))
+
+    if config.ip and config.ip is not None:
+        print 'Deploying by Rsync to %s:%s ...' % (config.ip, config.deploy_dir)
+        os.system("rsync -avz %s %s:%s" % (dir, config.ip, config.deploy_dir))
+    else:
+        print 'Deploying by Rsync to %s ...' % config.deploy_dir
+        os.system("rsync -avz %s %s" % (dir, config.deploy_dir))
 
 if __name__ == '__main__':
     rsync_deploy(dir)


### PR DESCRIPTION
Adding support for local rsync deployment by leaving deploy-ip empty. It's a quick change for my situation. Maybe rework this for me very important feature to work better in the future. But local deployment should be possible if you do your stuff on hosted boxes.